### PR TITLE
認証の戻りでエラーメッセージが表示されていない問題

### DIFF
--- a/app/GET/Zoho.php
+++ b/app/GET/Zoho.php
@@ -8,14 +8,14 @@ use Field;
 class Zoho extends ACMS_GET
 {
     /**
-     * エラーをセッションに登録し、リダイレクト後のメイン画面（Admin_Errors）でアラート表示させる。
+     * エラーをセッションに登録するヘルパーメソッド
      *
      * ACMS_POST::addError() と同じ形式でセッションの errors チャイルドに積むことで、
      * 標準の Admin_Errors モジュールがそのまま拾って表示する。
      *
      * @param string $detail エラーの詳細（例外メッセージなど）
      */
-    protected function addAuthError(string $detail = '')
+    protected function addError(string $detail = '')
     {
         $errors = new Field();
         $errors->addField('error', '【Zoho plugin】' . $detail);

--- a/app/GET/Zoho.php
+++ b/app/GET/Zoho.php
@@ -3,7 +3,24 @@
 namespace Acms\Plugins\Zoho\GET;
 
 use ACMS_GET;
+use Field;
 
 class Zoho extends ACMS_GET
 {
+    /**
+     * エラーをセッションに登録し、リダイレクト後のメイン画面（Admin_Errors）でアラート表示させる。
+     *
+     * ACMS_POST::addError() と同じ形式でセッションの errors チャイルドに積むことで、
+     * 標準の Admin_Errors モジュールがそのまま拾って表示する。
+     *
+     * @param string $detail エラーの詳細（例外メッセージなど）
+     */
+    protected function addAuthError(string $detail = '')
+    {
+        $errors = new Field();
+        $errors->addField('error', '【Zoho plugin】' . $detail);
+
+        $session =& Field::singleton('session');
+        $session->addChild('errors', $errors);
+    }
 }

--- a/app/GET/Zoho/Callback.php
+++ b/app/GET/Zoho/Callback.php
@@ -56,12 +56,12 @@ class Callback extends Zoho
             AcmsLogger::error('【Zoho plugin】OAuth認証処理でエラーが発生しました。', [
                 'message' => $e->getMessage(),
             ]);
-            $this->addAuthError($e->getMessage());
+            $this->addError($e->getMessage());
         } catch (\InvalidArgumentException $e) {
             AcmsLogger::error('【Zoho plugin】OAuth認証処理でエラーが発生しました。', [
                 'message' => $e->getMessage(),
             ]);
-            $this->addAuthError($e->getMessage());
+            $this->addError($e->getMessage());
         }
         $base_uri = acmsLink(array(
             'bid' => BID,

--- a/app/GET/Zoho/Callback.php
+++ b/app/GET/Zoho/Callback.php
@@ -2,15 +2,15 @@
 
 namespace Acms\Plugins\Zoho\GET\Zoho;
 
-use ACMS_GET;
 use DB;
 use SQL;
 use AcmsLogger;
 use Acms\Services\Facades\Session;
+use Acms\Plugins\Zoho\GET\Zoho;
 use Acms\Plugins\Zoho\Services\Zoho\Client as ZohoClient;
 use Acms\Plugins\Zoho\Services\Zoho\Api as ZohoApi;
 
-class Callback extends ACMS_GET
+class Callback extends Zoho
 {
     public function get()
     {
@@ -56,10 +56,12 @@ class Callback extends ACMS_GET
             AcmsLogger::error('【Zoho plugin】OAuth認証処理でエラーが発生しました。', [
                 'message' => $e->getMessage(),
             ]);
+            $this->addAuthError($e->getMessage());
         } catch (\InvalidArgumentException $e) {
             AcmsLogger::error('【Zoho plugin】OAuth認証処理でエラーが発生しました。', [
                 'message' => $e->getMessage(),
             ]);
+            $this->addAuthError($e->getMessage());
         }
         $base_uri = acmsLink(array(
             'bid' => BID,


### PR DESCRIPTION
認証の戻りでIPアドレス無許可などのエラーの場合に、管理画面上でエラーが表示されず動作の状況がわからなかったので、アラートを出せるようにしました。